### PR TITLE
Rename calcualteindex function

### DIFF
--- a/bsgsd.cpp
+++ b/bsgsd.cpp
@@ -116,7 +116,7 @@ void checkpointer(void *ptr,const char *file,const char *function,const  char *n
 void* client_handler(void* arg);
 
 
-void calcualteindex(int i,Int *key);
+void calculate_index(int i,Int *key);
 
 void *thread_process_bsgs(void *vargp);
 void *thread_bPload(void *vargp);
@@ -1890,7 +1890,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,Int *privatekey)	{
 		if(r)	{
 			r = bsgs_searchbinary(bPtable,xpoint_raw,bsgs_m3,&j);
 			if(r)	{
-				calcualteindex(i,&calculatedkey);
+				calculate_index(i,&calculatedkey);
 				privatekey->Set(&calculatedkey);
 				privatekey->Add((uint64_t)(j+1));
 				privatekey->Add(&base_key);
@@ -1901,7 +1901,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,Int *privatekey)	{
 					found = 1;
 				}
 				else	{
-					calcualteindex(i,&calculatedkey);
+					calculate_index(i,&calculatedkey);
 					privatekey->Set(&calculatedkey);
 					privatekey->Sub((uint64_t)(j+1));
 					privatekey->Add(&base_key);
@@ -1920,7 +1920,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,Int *privatekey)	{
 				This is is an special case
 			*/
 			if(BSGS_Q.x.IsEqual(&BSGS_AMP3[i].x))	{
-				calcualteindex(i,&calculatedkey);
+				calculate_index(i,&calculatedkey);
 				privatekey->Set(&calculatedkey);
 				privatekey->Add(&base_key);
 				found = 1;
@@ -1932,7 +1932,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,Int *privatekey)	{
 	return found;
 }
 
-void calcualteindex(int i,Int *key)	{
+void calculate_index(int i,Int *key)	{
 	if(i == 0)	{
 		key->Set(&BSGS_M3);
 	}

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -185,7 +185,7 @@ bool initBloomFilter(struct bloom *bloom_arg,uint64_t items_bloom);
 
 void writeFileIfNeeded(const char *fileName);
 
-void calcualteindex(int i,Int *key);
+void calculate_index(int i,Int *key);
 #if defined(_WIN64) && !defined(__CYGWIN__)
 DWORD WINAPI thread_process_vanity(LPVOID vargp);
 DWORD WINAPI thread_process_minikeys(LPVOID vargp);
@@ -4329,7 +4329,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,uint32_t k_index,Int *privatekey
 		if(r)	{
 			r = bsgs_searchbinary(bPtable,xpoint_raw,bsgs_m3,&j);
 			if(r)	{
-				calcualteindex(i,&calculatedkey);
+				calculate_index(i,&calculatedkey);
 				privatekey->Set(&calculatedkey);
 				privatekey->Add((uint64_t)(j+1));
 				privatekey->Add(&base_key);
@@ -4338,7 +4338,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,uint32_t k_index,Int *privatekey
 					found = 1;
 				}
 				else	{
-					calcualteindex(i,&calculatedkey);
+					calculate_index(i,&calculatedkey);
 					privatekey->Set(&calculatedkey);
 					privatekey->Sub((uint64_t)(j+1));
 					privatekey->Add(&base_key);
@@ -4356,7 +4356,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,uint32_t k_index,Int *privatekey
 				This is is an special case
 			*/
 			if(BSGS_Q.x.IsEqual(&BSGS_AMP3[i].x))	{
-				calcualteindex(i,&calculatedkey);
+				calculate_index(i,&calculatedkey);
 				privatekey->Set(&calculatedkey);
 				privatekey->Add(&base_key);
 				found = 1;
@@ -6677,7 +6677,7 @@ void writeFileIfNeeded(const char *fileName)	{
 	}
 }
 
-void calcualteindex(int i,Int *key)	{
+void calculate_index(int i,Int *key)	{
 	if(i == 0)	{
 		key->Set(&BSGS_M3);
 	}

--- a/keyhunt_legacy.cpp
+++ b/keyhunt_legacy.cpp
@@ -182,7 +182,7 @@ bool initBloomFilter(struct bloom *bloom_arg,uint64_t items_bloom);
 
 void writeFileIfNeeded(const char *fileName);
 
-void calcualteindex(int i,Int *key);
+void calculate_index(int i,Int *key);
 
 #if defined(_WIN64) && !defined(__CYGWIN__)
 DWORD WINAPI thread_process_vanity(LPVOID vargp);
@@ -4457,7 +4457,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,uint32_t k_index,Int *privatekey
 		if(r)	{
 			r = bsgs_searchbinary(bPtable,xpoint_raw,bsgs_m3,&j);
 			if(r)	{
-				calcualteindex(i,&calculatedkey);
+				calculate_index(i,&calculatedkey);
 				privatekey->Set(&calculatedkey);
 				privatekey->Add((uint64_t)(j+1));
 				privatekey->Add(&base_key);
@@ -4466,7 +4466,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,uint32_t k_index,Int *privatekey
 					found = 1;
 				}
 				else	{
-					calcualteindex(i,&calculatedkey);
+					calculate_index(i,&calculatedkey);
 					privatekey->Set(&calculatedkey);
 					privatekey->Sub((uint64_t)(j+1));
 					privatekey->Add(&base_key);
@@ -4484,7 +4484,7 @@ int bsgs_thirdcheck(Int *start_range,uint32_t a,uint32_t k_index,Int *privatekey
 				This is is an special case
 			*/
 			if(BSGS_Q.x.IsEqual(&BSGS_AMP3[i].x))	{
-				calcualteindex(i,&calculatedkey);
+				calculate_index(i,&calculatedkey);
 				privatekey->Set(&calculatedkey);
 				privatekey->Add(&base_key);
 				found = 1;
@@ -6916,7 +6916,7 @@ void writeFileIfNeeded(const char *fileName)	{
 }
 
 
-void calcualteindex(int i,Int *key)	{
+void calculate_index(int i,Int *key)	{
 	if(i == 0)	{
 		key->Set(&BSGS_M3);
 	}


### PR DESCRIPTION
## Summary
- rename `calcualteindex` to `calculate_index`
- update declarations and calls across keyhunt sources

## Testing
- `make`
- `make legacy`
- `make bsgsd`


------
https://chatgpt.com/codex/tasks/task_e_6887ec55f5848324a46300ac1fb30c2c